### PR TITLE
Add allowDashes, create test2

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,11 @@ var EMPTY = '';
  * @param {string} value - Value to normalize.
  * @param {boolean} allowApostrophes - Do not strip
  *   apostrophes.
+ * @param {boolean} allowDashes - Do not strip
+ *   dashes.
  * @return {string} - Normalized `value`.
  */
-function normalize(value, allowApostrophes) {
+function normalize(value, allowApostrophes, allowDashes) {
     var result = (typeof value === 'string' ? value : toString(value))
         .toLowerCase();
 
@@ -42,6 +44,13 @@ function normalize(value, allowApostrophes) {
         return result
             .replace(APOSTROPHE, QUOTE)
             .replace(DASH, EMPTY);
+    
+    }
+
+    if (allowDashes) {
+        return result
+            .replace(APOSTROPHE, EMPTY)
+            .replace(QUOTE, EMPTY);
     }
 
     return result.replace(ALL, EMPTY);

--- a/test.js
+++ b/test.js
@@ -133,6 +133,29 @@ test('normalize(value, allowApostrophes)', function (t) {
         'should normalize dashes (node)'
     );
 
+        t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'level'
+                }
+            ]
+        }, false, true),
+        'block-level',
+        'should not normalize dashes (node) when specified'
+    );
+
+
     t.equal(
         normalize([
             {
@@ -156,6 +179,12 @@ test('normalize(value, allowApostrophes)', function (t) {
         normalize('he’ll', true),
         'he\'ll',
         'should normalize apostrophes when specified'
+    );
+
+    t.equal(
+        normalize('drop-down menu', false, true),
+        'drop-down menu',
+        'should not normalize dashes when specified'
     );
 
     t.end();

--- a/test2.js
+++ b/test2.js
@@ -1,0 +1,43 @@
+var normalize = require('nlcst-normalize');
+
+console.log(normalize('Don’t', false)); // 'dont'
+console.log(normalize('Don\'t', false)); // 'dont'
+console.log(normalize('Block-level', false)); // 'blocklevel'
+console.log(normalize('Don’t', true)); // 'don\'t'
+console.log(normalize('Block-level', false, true)); // 'block-level'
+
+console.log(normalize({
+    'type': 'WordNode',
+    'children': [
+        {
+            'type': 'TextNode',
+            'value': 'Block'
+        },
+        {
+            'type': 'PunctuationNode',
+            'value': '-'
+        },
+        {
+            'type': 'TextNode',
+            'value': 'level'
+        }
+    ]
+}, false, true)); // 'block-level'
+
+console.log(normalize({
+    'type': 'WordNode',
+    'children': [
+        {
+            'type': 'TextNode',
+            'value': 'Block'
+        },
+        {
+            'type': 'PunctuationNode',
+            'value': '-'
+        },
+        {
+            'type': 'TextNode',
+            'value': 'level'
+        }
+    ]
+}, false, false)); // 'blocklevel'


### PR DESCRIPTION
I tried to replicate the way the `allowApostrophes` option is defined.

Test.js passes with my additions (requires `tape`).

I hacked together another test, test2.js, that just writes normalized values to the log.

At the moment I can get test2.js to write the correct values to the console only if I run it from where I was making changes to the installed version in the global npm modules directory: /usr/local/lib/node_modules/rorybot/node_modules/nlcst-normalize.

![image](https://cloud.githubusercontent.com/assets/16706135/14465414/eec10be8-00a0-11e6-8c35-a93e1200ad81.png)

When I run it from the github repo, it honours the `allowApostrophes` parameter but not the `allowDashes one`:
![image](https://cloud.githubusercontent.com/assets/16706135/14465433/0336621c-00a1-11e6-9908-1036ce61fa5a.png)

But for the moment, let's just assume this part works once installed as a dependency of nlcst-search>retext-shopify>rorybot, unless you can spot something that immediately seems wrong.
