### PR TITLE
Add dashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,16 +32,29 @@ var EMPTY = '';
  * @param {string} value - Value to normalize.
  * @param {boolean} allowApostrophes - Do not strip
  *   apostrophes.
+ * @param {boolean} allowDashes - Do not strip
+ *   dashes.
  * @return {string} - Normalized `value`.
  */
-function normalize(value, allowApostrophes) {
+function normalize(value, allowApostrophes, allowDashes) {
     var result = (typeof value === 'string' ? value : toString(value))
         .toLowerCase();
+
+    if (allowApostrophes && allowDashes) {
+        return result;
+    }
 
     if (allowApostrophes) {
         return result
             .replace(APOSTROPHE, QUOTE)
             .replace(DASH, EMPTY);
+
+    }
+
+    if (allowDashes) {
+        return result
+            .replace(APOSTROPHE, EMPTY)
+            .replace(QUOTE, EMPTY);
     }
 
     return result.replace(ALL, EMPTY);

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ var normalize = require('./');
  * Tests.
  */
 
-test('normalize(value, allowApostrophes)', function (t) {
+test('Basic', function (t) {
     t.throws(
         function () {
             normalize(true);
@@ -29,28 +29,14 @@ test('normalize(value, allowApostrophes)', function (t) {
         'should fail when given a boolean'
     );
 
+    t.end();
+});
+
+test('Case', function (t) {
     t.equal(
         normalize('Dont'),
         'dont',
         'should normalize case (string)'
-    );
-
-    t.equal(
-        normalize('Don\'t'),
-        'dont',
-        'should normalize dumb apostrophes (string)'
-    );
-
-    t.equal(
-        normalize('Don’t'),
-        'dont',
-        'should normalize smart apostrophes (string)'
-    );
-
-    t.equal(
-        normalize('Block-level'),
-        'blocklevel',
-        'should normalize dashes (string)'
     );
 
     t.equal(
@@ -65,72 +51,6 @@ test('normalize(value, allowApostrophes)', function (t) {
         }),
         'dont',
         'should normalize case (node)'
-    );
-
-    t.equal(
-        normalize({
-            'type': 'WordNode',
-            'children': [
-                {
-                    'type': 'TextNode',
-                    'value': 'Don'
-                },
-                {
-                    'type': 'PunctuationNode',
-                    'value': '\''
-                },
-                {
-                    'type': 'TextNode',
-                    'value': 't'
-                }
-            ]
-        }),
-        'dont',
-        'should normalize dumb apostrophes (node)'
-    );
-
-    t.equal(
-        normalize({
-            'type': 'WordNode',
-            'children': [
-                {
-                    'type': 'TextNode',
-                    'value': 'Don'
-                },
-                {
-                    'type': 'PunctuationNode',
-                    'value': '’'
-                },
-                {
-                    'type': 'TextNode',
-                    'value': 't'
-                }
-            ]
-        }),
-        'dont',
-        'should normalize smart apostrophes (node)'
-    );
-
-    t.equal(
-        normalize({
-            'type': 'WordNode',
-            'children': [
-                {
-                    'type': 'TextNode',
-                    'value': 'Block'
-                },
-                {
-                    'type': 'PunctuationNode',
-                    'value': '-'
-                },
-                {
-                    'type': 'TextNode',
-                    'value': 'level'
-                }
-            ]
-        }),
-        'blocklevel',
-        'should normalize dashes (node)'
     );
 
     t.equal(
@@ -149,14 +69,798 @@ test('normalize(value, allowApostrophes)', function (t) {
             }
         ]),
         'blocklevel',
-        'should normalize multiple nodes'
-    );
-
-    t.equal(
-        normalize('he’ll', true),
-        'he\'ll',
-        'should normalize apostrophes when specified'
+        'should normalize case (multiple nodes)'
     );
 
     t.end();
 });
+
+test('Apostrophes', function (t) {
+    t.equal(
+        normalize('Don\'t Block-Level'),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (string)'
+    );
+
+    t.equal(
+        normalize('Don’t Block-Level'),
+        'dont blocklevel',
+        'should normalize smart apostrophes (string)'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (node)'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '’'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }),
+        'dont blocklevel',
+        'should normalize smart apostrophes (node)'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ]),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (multiple nodes)'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '’'
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ]),
+        'dont blocklevel',
+        'should normalize smart apostrophes (multiple nodes)'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', false),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (string) if false'
+    );
+
+    t.equal(
+        normalize('Don’t Block-Level', false),
+        'dont blocklevel',
+        'should normalize smart apostrophes (string) if false'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, false),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (node) if false'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '’'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, false),
+        'dont blocklevel',
+        'should normalize smart apostrophes (node) if false'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], false),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (multiple nodes) if false'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '’'
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], false),
+        'dont blocklevel',
+        'should normalize smart apostrophes (multiple nodes) if false'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', true),
+        'don\'t blocklevel',
+        'should not normalize dumb apostrophes (string) if true'
+    );
+
+    t.equal(
+        normalize('Don’t Block-Level', true),
+        'don\'t blocklevel',
+        'should normalize smart apostrophes (string) if true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, true),
+        'don\'t blocklevel',
+        'should not normalize dumb apostrophes (node) if true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '’'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, true),
+        'don\'t blocklevel',
+        'should normalize smart apostrophes (node) if true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], true),
+        'don\'t blocklevel',
+        'should not normalize dumb apostrophes (multiple nodes) if true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '’'
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], true),
+        'don\'t blocklevel',
+        'should normalize smart apostrophes (multiple nodes) if true'
+    );
+
+    t.end();
+});
+
+test('Dashes', function (t) {
+    t.equal(
+        normalize('Don\'t Block-Level'),
+        'dont blocklevel',
+        'should normalize dashes (string)'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }),
+        'dont blocklevel',
+        'should normalize dashes (node)'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ]),
+        'dont blocklevel',
+        'should normalize dashes (multiple nodes)'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', false, false),
+        'dont blocklevel',
+        'should normalize dashes (string) if false'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', true, false),
+        'don\'t blocklevel',
+        'should normalize dashes (string) if false and apos true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, false, false),
+        'dont blocklevel',
+        'should normalize dashes (node) if false'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, true, false),
+        'don\'t blocklevel',
+        'should normalize dashes (node) if false and apos true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], false, false),
+        'dont blocklevel',
+        'should normalize dashes (multiple nodes) if false'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], true, false),
+        'don\'t blocklevel',
+        'should normalize dashes (multiple nodes) if false and apos true'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', false, true),
+        'dont block-level',
+        'should not normalize dashes (string) if true'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', true, true),
+        'don\'t block-level',
+        'should not normalize dashes (string) if true and apos true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, false, true),
+        'dont block-level',
+        'should not normalize dashes (node) if true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, true, true),
+        'don\'t block-level',
+        'should not normalize dashes (node) if true and apos true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], false, true),
+        'dont block-level',
+        'should not normalize dashes (multiple nodes) if true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], true, true),
+        'don\'t block-level',
+        'should not normalize dashes (multiple nodes) if true and apos true'
+    );
+
+    t.end();
+});
+


### PR DESCRIPTION
@jeremyhansonfinger I had to add a million tests to figure out what was wrong; I figure it doesn’t hurt to keep them in.

Issue in this repo was that we weren’t checking for the case where both `allowApostrophes` and `allowDashes` were true. Before, if `allowApostrophes` was true, `allowDashes` got ignored.
